### PR TITLE
Allow configuration values to be provided by files

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,9 +278,14 @@ By default, the storage server uses SQLite and the filesystem. The behavior of t
 | MRD_STORAGE_SERVER_STORAGE_PORT               | integer | The port to listen on.                                                                                                   | 3333                |
 | MRD_STORAGE_SERVER_STORAGE_LOG_REQUESTS       | boolean | Whether to log the URI, status code, and duration of each HTTP request.                                                  | true                |
 
+In addition, any of the above values can be provided by a file instead of being stored in environment variables, where they could end up exposed by logging tools. To do this, append `_FILE` to the environment variable name and provide the file path as the value. For example, you can write the database connection string to a file, and set the following environment variable pointing to the file:
+
+```bash
+export MRD_STORAGE_SERVER_DATABASE_CONNECTION_STRING_FILE="/path/to/the/connection_string_file.txt"
+```
+
 ## TODO:
 
-- Handle secrets as files
 - Migration tool
 - Support Azure Managed identity
 - Support Delete

--- a/README.md
+++ b/README.md
@@ -278,7 +278,7 @@ By default, the storage server uses SQLite and the filesystem. The behavior of t
 | MRD_STORAGE_SERVER_STORAGE_PORT               | integer | The port to listen on.                                                                                                   | 3333                |
 | MRD_STORAGE_SERVER_STORAGE_LOG_REQUESTS       | boolean | Whether to log the URI, status code, and duration of each HTTP request.                                                  | true                |
 
-In addition, any of the above values can be provided by a file instead of being stored in environment variables, where they could end up exposed by logging tools. To do this, append `_FILE` to the environment variable name and provide the file path as the value. For example, you can write the database connection string to a file, and set the following environment variable pointing to the file:
+In addition, any of the above values can be provided as a file instead of being stored in environment variables, where they could end up exposed by logging tools. To do this, append `_FILE` to the environment variable name and provide the file path as the value. For example, you can write the database connection string to a file, and set the following environment variable pointing to the file:
 
 ```bash
 export MRD_STORAGE_SERVER_DATABASE_CONNECTION_STRING_FILE="/path/to/the/connection_string_file.txt"

--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 
 require (
 	github.com/golang/mock v1.6.0
-	github.com/johnstairs/pathenvconfig v0.0.0-20211210234032-57b1cc5a14d1
+	github.com/johnstairs/pathenvconfig v0.1.0
 	github.com/stretchr/testify v1.7.0
 )
 

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 
 require (
 	github.com/Azure/azure-pipeline-go v0.2.3 // indirect
+	github.com/dlclark/regexp2 v1.4.0 // indirect
 	github.com/google/uuid v1.2.0 // indirect
 	github.com/jackc/chunkreader/v2 v2.0.1 // indirect
 	github.com/jackc/pgconn v1.10.0 // indirect
@@ -31,6 +32,7 @@ require (
 
 require (
 	github.com/golang/mock v1.6.0
+	github.com/johnstairs/pathenvconfig v0.0.0-20211210234032-57b1cc5a14d1
 	github.com/stretchr/testify v1.7.0
 )
 
@@ -39,7 +41,6 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/go-chi/chi/v5 v5.0.4
 	github.com/gofrs/uuid v4.0.0+incompatible
-	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/sirupsen/logrus v1.8.1
 	github.com/xorcare/pointer v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -24,6 +24,8 @@ github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7Do
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dlclark/regexp2 v1.4.0 h1:F1rxgk7p4uKjwIQxBs9oAXe5CqrXlCduYEJvrF4u93E=
+github.com/dlclark/regexp2 v1.4.0/go.mod h1:2pZnwuY/m+8K6iRw6wQdMtk+rH5tNGR1i55kozfMjCc=
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible h1:TcekIExNqud5crz4xD2pavyTgWiPvpYe4Xau31I0PRk=
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
 github.com/go-chi/chi/v5 v5.0.4 h1:5e494iHzsYBiyXQAHHuI4tyJS9M3V84OuX3ufIIGHFo=
@@ -89,8 +91,8 @@ github.com/jinzhu/inflection v1.0.0 h1:K317FqzuhWc8YvSVlFMCCUb36O/S9MCKRDI7QkRKD
 github.com/jinzhu/inflection v1.0.0/go.mod h1:h+uFLlag+Qp1Va5pdKtLDYj+kHp5pxUVkryuEj+Srlc=
 github.com/jinzhu/now v1.1.2 h1:eVKgfIdy9b6zbWBMgFpfDPoAMifwSZagU9HmEU6zgiI=
 github.com/jinzhu/now v1.1.2/go.mod h1:d3SSVoowX0Lcu0IBviAWJpolVfI5UJVZZ7cO71lE/z8=
-github.com/kelseyhightower/envconfig v1.4.0 h1:Im6hONhd3pLkfDFsbRgu68RDNkGF1r3dvMUtDTo2cv8=
-github.com/kelseyhightower/envconfig v1.4.0/go.mod h1:cccZRl6mQpaq41TPp5QxidR+Sa3axMbJDNb//FQX6Gg=
+github.com/johnstairs/pathenvconfig v0.0.0-20211210234032-57b1cc5a14d1 h1:7i58CUdc7SRFjGUu/E6noI5+yEREz2sf80rzdYICvwY=
+github.com/johnstairs/pathenvconfig v0.0.0-20211210234032-57b1cc5a14d1/go.mod h1:XqBReihWnlfmCkHqvJAfsRCfa/JJCYXZds8fwtuz8cM=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=

--- a/go.sum
+++ b/go.sum
@@ -91,8 +91,8 @@ github.com/jinzhu/inflection v1.0.0 h1:K317FqzuhWc8YvSVlFMCCUb36O/S9MCKRDI7QkRKD
 github.com/jinzhu/inflection v1.0.0/go.mod h1:h+uFLlag+Qp1Va5pdKtLDYj+kHp5pxUVkryuEj+Srlc=
 github.com/jinzhu/now v1.1.2 h1:eVKgfIdy9b6zbWBMgFpfDPoAMifwSZagU9HmEU6zgiI=
 github.com/jinzhu/now v1.1.2/go.mod h1:d3SSVoowX0Lcu0IBviAWJpolVfI5UJVZZ7cO71lE/z8=
-github.com/johnstairs/pathenvconfig v0.0.0-20211210234032-57b1cc5a14d1 h1:7i58CUdc7SRFjGUu/E6noI5+yEREz2sf80rzdYICvwY=
-github.com/johnstairs/pathenvconfig v0.0.0-20211210234032-57b1cc5a14d1/go.mod h1:XqBReihWnlfmCkHqvJAfsRCfa/JJCYXZds8fwtuz8cM=
+github.com/johnstairs/pathenvconfig v0.1.0 h1:V/UR8ly5XfHwKt5e68XyB+uYXDTT0m72Yv9JZiJ3oMg=
+github.com/johnstairs/pathenvconfig v0.1.0/go.mod h1:XqBReihWnlfmCkHqvJAfsRCfa/JJCYXZds8fwtuz8cM=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=

--- a/main.go
+++ b/main.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/kelseyhightower/envconfig"
+	"github.com/johnstairs/pathenvconfig"
 	log "github.com/sirupsen/logrus"
 
 	"github.com/ismrmrd/mrd-storage-server/api"
@@ -39,7 +39,7 @@ func main() {
 
 func loadConfig() ConfigSpec {
 	var config ConfigSpec
-	err := envconfig.Process("MRD_STORAGE_SERVER", &config)
+	err := pathenvconfig.Process("MRD_STORAGE_SERVER", &config)
 	if err != nil {
 		log.Fatal(err.Error())
 	}
@@ -104,10 +104,10 @@ func garbageCollectionLoop(ctx context.Context, db core.MetadataDatabase, blobSt
 }
 
 type ConfigSpec struct {
-	DatabaseProvider         string `split_words:"true" default:"sqlite"`
-	DatabaseConnectionString string `split_words:"true" default:"/data/metadata.db"`
-	StorageProvider          string `split_words:"true" default:"filesystem"`
-	StorageConnectionString  string `split_words:"true" default:"/data/blobs"`
-	Port                     int    `split_words:"true" default:"3333"`
-	LogRequests              bool   `split_words:"true" default:"true"`
+	DatabaseProvider         string `default:"sqlite"`
+	DatabaseConnectionString string `default:"/data/metadata.db"`
+	StorageProvider          string `default:"filesystem"`
+	StorageConnectionString  string `default:"/data/blobs"`
+	Port                     int    `default:"3333"`
+	LogRequests              bool   `default:"true"`
 }


### PR DESCRIPTION
Mounting secrets as environment variables can lead to logging tools leaking your secrets, so a safer option is to mount them as files. Now, if you add the suffix `_FILE` to a configuration environment variable name, the value can point to a file, which contains the real value. 

This is not supported in the `envconfig` module we were using (see [here](https://github.com/kelseyhightower/envconfig/issues/130)), so I implemented my own simple config module that is very similar but supports this functionality.