### PR TITLE
Add option to exit when parent process exits

### DIFF
--- a/main.go
+++ b/main.go
@@ -34,11 +34,10 @@ type Args struct {
 }
 
 func main() {
-	args := Args{RequireParentPid: -1}
+	args := Args{}
 	kong.Parse(&args, kong.UsageOnError())
 
 	configureZerolog(args)
-	fmt.Println(args)
 
 	startParentProcessCheck(args)
 

--- a/main.go
+++ b/main.go
@@ -28,15 +28,19 @@ const (
 )
 
 type Args struct {
-	PrettyPrint bool   `help:"Pretty-print logs." short:"p"`
-	LogLevel    string `help:"Set the minimum log level to emit." short:"l" default:"Info" enum:"Debug,Info,Warn,Error,Fatal,Panic,Disabled"`
+	PrettyPrint      bool   `help:"Pretty-print logs." short:"p"`
+	LogLevel         string `help:"Set the minimum log level to emit." short:"l" default:"Info" enum:"Debug,Info,Warn,Error,Fatal,Panic,Disabled"`
+	RequireParentPid int    `help:"Exit when the parent process' PID differs from the given value." default:"-1" hidden:""`
 }
 
 func main() {
-	args := Args{}
+	args := Args{RequireParentPid: -1}
 	kong.Parse(&args, kong.UsageOnError())
 
 	configureZerolog(args)
+	fmt.Println(args)
+
+	startParentProcessCheck(args)
 
 	config := loadConfig()
 
@@ -155,6 +159,24 @@ func configureZerolog(args Args) {
 	}
 
 	zerolog.DefaultContextLogger = &log.Logger
+}
+
+func startParentProcessCheck(args Args) {
+	if args.RequireParentPid < 0 {
+		return
+	}
+
+	// This is an undocumented "feature" to terminate this process when its parent process exits.
+	// When the parent process exits, this process will be adopted by the init process (PID 1) and therefore
+	// the call to os.Getppdid() will start returning 1.
+	go func() {
+		for {
+			if os.Getppid() != args.RequireParentPid {
+				log.Fatal().Msg("Terminating because the parent process has exited")
+			}
+			time.Sleep(time.Second)
+		}
+	}()
 }
 
 type ConfigSpec struct {


### PR DESCRIPTION
Adding a hidden command-line switch to allow the storage server to exit when the process that launched it exits. 

The scenario is: 
1. Gadgetron launches the storage server
2. Gadgetron crashes without terminating the storage server
3. Gadgetron starts up again and tries to launch the storage server again. This fails because storage server is still running and is already listening on its port.

The fix proposed here is to launch the storage server with `--require-parent-pid <PID>` which will start a background loop checking the current parent PID. When the parent exits, the parent PID will become 1, and we will exit the process. 